### PR TITLE
qmldir: rename Qt.Quick as QtQuick for Qt5.6.0

### DIFF
--- a/src/halremotecontrols/qmldir
+++ b/src/halremotecontrols/qmldir
@@ -4,8 +4,8 @@ classname MachinekitHalRemoteControlsPlugin
 typeinfo plugins.qmltypes
 designersupported
 
-depends Qt.Quick.Controls 1.1
-depends Qt.Quick.Window 2.0
+depends QtQuick.Controls 1.1
+depends QtQuick.Window 2.0
 depends Machinekit.HalRemote 1.0
 depends Machinekit.Service 1.0
 


### PR DESCRIPTION
src/halremotecontrols/qmldir: rename Qt.Quick as QtQuick for Qt5.6.0
Otherwise, the qmlplugindump may complain about can not find Qt.Quick*.
Upgrade to Qt5.6.0, solved #40 -- Debian Jessie - Service discover not working.