### PR TITLE
TouchOffDialog offset correction for when units are not in mm.

### DIFF
--- a/src/applicationcontrols/TouchOffDialog.qml
+++ b/src/applicationcontrols/TouchOffDialog.qml
@@ -58,7 +58,7 @@ Dialog {
             }
             var axisName = _axisNames[axis]
             var position = status.motion.position[axisName] - status.motion.g92Offset[axisName] - status.io.toolOffset[axisName]
-            var newOffset = (position - coordinateSpin.value) / status.config.axis[axis].units
+            var newOffset = (position - coordinateSpin.value)
             var mdi = "G10 L2 P" + (coordinateSystemCombo.currentIndex + 1) + " " + axisNames[axis] + newOffset.toFixed(6)
             command.executeMdi('execute', mdi)
         }


### PR DESCRIPTION
When using the touch off dialog and the machine units are not in mm, the offset is incorrectly set to the position divided by the ratio of machine units to mm (i.e., this division is benign when the units are mm). This makes Cetus, for example, set a work offset of 2.0 inches incorrectly to 50.7999.